### PR TITLE
fix(store): restart order beep for new realtime orders

### DIFF
--- a/enatega-multivendor-store/lib/context/global/sound.context.tsx
+++ b/enatega-multivendor-store/lib/context/global/sound.context.tsx
@@ -16,8 +16,9 @@ const SoundContext = createContext<ISoundContext>({} as ISoundContext);
 export const SoundProvider = ({ children }: ISoundContextProviderProps) => {
   const soundRef = useRef<ReturnType<typeof createAudioPlayer> | null>(null);
   const silencedRef = useRef(false);
+  const silencedOrderIdsRef = useRef("");
   // Context/Hooks
-  const { hasNewOrders } = useOrders();
+  const { hasNewOrders, ringedOrderIds } = useOrders();
 
   // Handlers
   const playSound = async () => {
@@ -38,7 +39,7 @@ export const SoundProvider = ({ children }: ISoundContextProviderProps) => {
 
       soundRef.current = newSound;
     } catch {
-      // Ignore audio startup failures and keep the app usable.
+      // no-op: keep the app usable if audio startup fails.
     }
   };
 
@@ -48,27 +49,37 @@ export const SoundProvider = ({ children }: ISoundContextProviderProps) => {
       soundRef.current = null;
       try {
         player.pause();
-      } catch {}
+      } catch {
+        // no-op: player may already be disposed.
+      }
       try {
         await player.seekTo(0);
-      } catch {}
+      } catch {
+        // no-op: player may already be disposed.
+      }
       try {
         await player.stop();
-      } catch {}
+      } catch {
+        // no-op: player may already be disposed.
+      }
       try {
         player.remove();
-      } catch {}
+      } catch {
+        // no-op: player may already be disposed.
+      }
     }
   };
 
   const silenceRing = async () => {
     silencedRef.current = true;
+    silencedOrderIdsRef.current = ringedOrderIds;
     await stopSound();
   };
 
   useEffect(() => {
     if (!hasNewOrders) {
       silencedRef.current = false;
+      silencedOrderIdsRef.current = "";
       stopSound();
       return () => {
         stopSound();
@@ -76,9 +87,14 @@ export const SoundProvider = ({ children }: ISoundContextProviderProps) => {
     }
 
     if (hasNewOrders) {
-      if (silencedRef.current) {
+      if (
+        silencedRef.current &&
+        silencedOrderIdsRef.current === ringedOrderIds
+      ) {
         stopSound();
       } else if (!soundRef.current) {
+        silencedRef.current = false;
+        silencedOrderIdsRef.current = "";
         playSound();
       }
     }
@@ -86,7 +102,7 @@ export const SoundProvider = ({ children }: ISoundContextProviderProps) => {
     return () => {
       stopSound();
     };
-  }, [hasNewOrders]);
+  }, [hasNewOrders, ringedOrderIds]);
 
   return (
     <SoundContext.Provider value={{ playSound, stopSound, silenceRing }}>

--- a/enatega-multivendor-store/lib/hooks/useOrders.ts
+++ b/enatega-multivendor-store/lib/hooks/useOrders.ts
@@ -31,6 +31,12 @@ export default function useOrders() {
 
   const hasNewOrders =
     activeOrders?.some((order: IOrder) => Boolean(order?.isRinged)) ?? false;
+  const ringedOrderIds =
+    activeOrders
+      ?.filter((order: IOrder) => Boolean(order?.isRinged))
+      .map((order: IOrder) => order?._id)
+      .sort()
+      .join(",") ?? "";
 
   return {
     loading,
@@ -39,6 +45,7 @@ export default function useOrders() {
     refetch,
     networkStatus,
     hasNewOrders,
+    ringedOrderIds,
     activeOrders,
     processingOrders,
     deliveredOrders,


### PR DESCRIPTION
Track the currently ringed pending order IDs in useOrders and let the sound provider compare that batch against the batch silenced by accept/cancel actions.

Previously, accepting one order stopped the beep and left the sound provider silenced while hasNewOrders stayed true because other pending ringed orders still existed. Since the boolean never changed, a later realtime order could not trigger the effect again.

Now a new realtime order changes the ringed order ID key, clears the silenced state, and starts the alert sound again while preserving the existing behavior of stopping the current batch on accept.

Verification: npx eslint lib/hooks/useOrders.ts lib/context/global/sound.context.tsx