### PR TITLE
fix discovery navigation stack header issue: 

### DIFF
--- a/enatega-multivendor-app/src/routes/index.js
+++ b/enatega-multivendor-app/src/routes/index.js
@@ -29,6 +29,7 @@ import CartAddress from '../screens/CartAddress/CartAddress'
 import Settings from '../screens/Settings/Settings'
 import HelpBrowser from '../screens/HelpBrowser/HelpBrowser'
 import Main from '../screens/Main/Main'
+import mainNavigationOptions from '../screens/Main/navigationOptions'
 import Restaurant from '../screens/Restaurant/Restaurant'
 import About from '../screens/About'
 import SelectLocation from '../screens/SelectLocation'
@@ -279,9 +280,15 @@ function BottomTabNavigator() {
       <Tab.Screen
         name='Discovery'
         component={Main}
-        options={{
-          tabBarLabel: t('Discovery')
-        }}
+        options={({ navigation }) => ({
+          tabBarLabel: t('Discovery'),
+          ...mainNavigationOptions({
+            headerMenuBackground: currentTheme.themeBackground,
+            fontMainColor: currentTheme.darkBgFont,
+            navigation,
+            open: () => {}
+          })
+        })}
       />
       <Tab.Screen
         name='Restaurants'

--- a/enatega-multivendor-app/src/screens/Login/useLogin.js
+++ b/enatega-multivendor-app/src/screens/Login/useLogin.js
@@ -128,10 +128,16 @@ export const useLogin = () => {
           name: data.login.name,
           email: data.login.email
         })
-        // Leave the guest Profile tab before authentication swaps it to the
-        // real Profile screen, otherwise Profile flashes before Discovery.
-        navigation.navigate('Main', { screen: 'Discovery' })
         await setTokenAsync(data.login.token)
+        navigation.reset({
+          index: 0,
+          routes: [
+            {
+              name: 'Main',
+              params: { screen: 'Discovery' }
+            }
+          ]
+        })
       } catch (e) {
         if (__DEV__) console.log(e)
       }


### PR DESCRIPTION
Login still saves the token and resets to authenticated Discovery.

  - Discovery now renders the location header immediately from navigator initialization.
  - The temporary default “Discovery” title no longer appears.